### PR TITLE
Fixed image preprocessing in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,9 @@ transform = transforms.Compose([
 ])
 def load_image(name):
     img_pil = Image.open(name)
-    return transform(img_pil)
+    return transform(img_pil).unsqueeze(0)
 
-imgs = torch.as_tensor([load_image('poodle.jpg', 'husky.jpg', 'cat.jpg')])
+imgs = torch.cat([load_image('poodle.jpg'), load_image('husky.jpg'), load_image('cat.jpg')], dim=0)
 ```
 
 ### Compute Image Embedding


### PR DESCRIPTION
- `load_image` only takes one parameter, but three were passed.
- To form a batch images must have dims `1xCxHxW`
- Using `torch.cat` to form the batch of size `NxCxHxW`